### PR TITLE
F# Discriminated Unions and real Pattern Matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,22 +185,24 @@ and PortfolioArchived = { PortfolioId : int; Name : string }
 module TSql =
     let Int value = TSql.Int <| Nullable value
 
+let (|TSqlInt|) = TSql.Int
+let (|TSqlVarCharMax|) = TSql.VarCharMax
+
 let projectPortfolioEvent = function
-    | PortfolioCreated m -> 
+    | PortfolioCreated { PortfolioId = TSqlInt portfolioId; Name = TSqlVarCharMax name } -> 
         TSql.NonQuery(
             "INSERT INTO [PortfolioPhotoCount] ([Id], [Name], [PhotoCount]) VALUES (@Id, @Name, @PhotoCount)", 
-            [   "Id", m.PortfolioId |> TSql.Int          
-                "Name", m.Name |> TSql.VarCharMax   
-                "PhotoCount", 0 |> TSql.Int ])
-    | PhotoAdded m ->
+            [ "Id", portfolioId; "Name", name; "PhotoCount", TSql.Int 0 ])
+    | PhotoAdded { PortfolioId = TSqlInt portfolioId } ->
         TSql.NonQuery(
             "UPDATE [PortfolioPhotoCount] SET [PhotoCount] = [PhotoCount] + 1 WHERE [Id] = @Id", 
-            [ "Id", m.PortfolioId |> TSql.Int ])
-    | PhotoRemoved m ->
+            [ "Id", portfolioId ])
+    | PhotoRemoved { PortfolioId = TSqlInt portfolioId } ->
         TSql.NonQuery(
             "UPDATE [PortfolioPhotoCount] SET [PhotoCount] = [PhotoCount] - 1 WHERE [Id] = @Id", 
-            [ "Id", m.PortfolioId |> TSql.Int ])
-    | PortfolioArchived m ->
+            [ "Id", portfolioId ])
+    | PortfolioArchived { PortfolioId = TSqlInt portfolioId } ->
         TSql.NonQueryFormat(
             "DELETE FROM [PortfolioPhotoCount] WHERE [Id] = {0}", 
-            m.PortfolioId |> TSql.Int )```
+            portfolioId )
+```


### PR DESCRIPTION
As discussed on https://jabbr.net/#/rooms/DDD-CQRS-ES today

Notes:
1. 3rd commit actually compiles (prev 2 can be fixed if you prefer them)
2. Getting stuff into the DU is possible, but more interesting that getting stuff into a normal record e.g. 
    - Json.net supports it but there are reasons not to use it OOTB, see what FunDomain does) 
    - protobuf is also messy, see recent SO posts by me if that matters
3. 4th commit applied Active Patterns to compose the SQL args. May or may not be a good idea to show in a simple sample
4. I think Projac should not do stuff with `FSharpOption` directly - v few libs to this. as demonstrated in the final commit, small one liner glue things in the F# make it work just fine

It might be a good idea to put a `.fs` file with helpers and an example in a nuget that references Projac and let that be the F# support?
